### PR TITLE
PUL-5944: Allow setting connection pool timeout and size through ENV

### DIFF
--- a/lib/relax/base.rb
+++ b/lib/relax/base.rb
@@ -12,7 +12,10 @@ module Relax
       end
 
       if !defined?(@@conn)
-        @@conn = ConnectionPool.new(timeout: 1, size: 2) do
+        timeout = ENV.fetch('RELAX_REDIS_CONN_POOL_TIMEOUT') { 1 }
+        size = ENV.fetch('RELAX_REDIS_CONN_POOL_SIZE') { 2 }
+
+        @@conn = ConnectionPool.new(timeout: timeout.to_i, size: size.to_i) do
           Redis.new(url: redis_uri, db: 0)
         end
       end


### PR DESCRIPTION
Based on [this comment](https://jira.reflektive.com/browse/PUL-5944?focusedCommentId=24557&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-24557) from the issue. We allow setting the connection pool size and timeout to avoid timeout errors we've been getting recently.