### PR TITLE
allow greater json version

### DIFF
--- a/relax-rb.gemspec
+++ b/relax-rb.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency             "redis",   "~> 3.2.1"
-  spec.add_dependency             "json",    "~> 1.8.3"
+  spec.add_dependency             "json",    ">= 1.8.3"
   spec.add_dependency             "connection_pool", "~> 2.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"


### PR DESCRIPTION
To upgrade to Rails 5 we need upgrade JWT, and for upgrade JWT we need upgrade json gem that is lock for this gem. This commit relax the version of JSON gem.