### PR TITLE
Relax `relax-rb` Dependencies

### DIFF
--- a/relax-rb.gemspec
+++ b/relax-rb.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "redis",   "~> 3.2.1"
+  spec.add_dependency             "redis",   ">= 3.2.1"
   spec.add_dependency             "json",    ">= 1.8.3"
   spec.add_dependency             "connection_pool", "~> 2.2.0"
 

--- a/relax-rb.gemspec
+++ b/relax-rb.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency             "redis",   ">= 3.2.1"
   spec.add_dependency             "json",    ">= 1.8.3"
-  spec.add_dependency             "connection_pool", "~> 2.2.0"
+  spec.add_dependency             "connection_pool", ">= 2.2.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/relax-rb.gemspec
+++ b/relax-rb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency             "json",    ">= 1.8.3"
   spec.add_dependency             "connection_pool", "~> 2.2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake",    "~> 10.0"
-  spec.add_development_dependency "rspec",   "~> 3.3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 end

--- a/spec/relax/event_listener_spec.rb
+++ b/spec/relax/event_listener_spec.rb
@@ -18,7 +18,7 @@ describe Relax::EventListener do
         @redis = Redis.new(uri: URI.parse("redis://localhost:6379"), db: 0)
         @thread = Thread.new { Relax::EventListener.listen! }
 
-        Relax::EventListener.callback = Proc.new { |e| @event = e; @thread.join }
+        Relax::EventListener.callback = Proc.new { |e| @event = e; Thread.current.terminate }
 
         @redis.rpush(ENV['RELAX_EVENTS_QUEUE'], {
           type: 'message_new',
@@ -36,6 +36,7 @@ describe Relax::EventListener do
 
       after do
         ENV['RELAX_EVENTS_QUEUE'] = nil
+        @thread.join
       end
 
       it 'should callback with the event' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require 'relax'
+
+Thread.abort_on_exception = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,1 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-
 require 'relax'


### PR DESCRIPTION
Originally, `relax-rb` locked `redis` to 3.2.2 at the latest, which was released in Nov 2015, uses now-deprecated Ruby APIs, and is succeeded by more recent versions with fewer bugs and more features. This PR also addresses some other changes:

**Changes**
- Fixes silently failing test (ThreadError)
- Removes locks on development dependencies
- Allow more lenient `redis` and `connection_pool` requirements