### PR TITLE
PUL-20648: Accept thread_timestamp

### DIFF
--- a/lib/relax/event.rb
+++ b/lib/relax/event.rb
@@ -2,7 +2,7 @@ module Relax
   class Event
     ATTRIBUTES = [:type, :user_uid, :channel_uid, :team_uid, :im, :text,
                   :relax_bot_uid, :timestamp, :provider, :event_timestamp,
-                  :namespace, :attachments]
+                  :thread_timestamp, :namespace, :attachments]
 
     attr_accessor *ATTRIBUTES
 


### PR DESCRIPTION
Jira: https://jira.reflektive.com/browse/PUL-20648

We're pulling in an important attribute from the Slack message through Relax. This is required for thread related features.

This is related to the change in relax: https://github.com/PulseSoftwareInc/relax/pull/3

Relevant lines:
https://github.com/PulseSoftwareInc/relax-rb/blob/master/lib/relax/event_listener.rb#L21
https://github.com/PulseSoftwareInc/relax-rb/blob/master/lib/relax/event.rb#L10